### PR TITLE
Initial changes setting the foundation for Account Editing feature

### DIFF
--- a/components/authPages/ButtonWithLoader.tsx
+++ b/components/authPages/ButtonWithLoader.tsx
@@ -5,25 +5,18 @@ type ButtonTypes = {
     disabled: boolean
     loading: boolean
     text: string
-    onSubmit: any // TODO: Figure out how to TS this material bs...
-    // onSubmit: MouseEventHandler<HTMLAnchorElement>
 }
 
-const ButtonWithLoader = ({
-    disabled,
-    loading,
-    text,
-    onSubmit
-}: ButtonTypes) => {
+const ButtonWithLoader = ({ disabled, loading, text }: ButtonTypes) => {
     return (
         <LoadingButton
             variant="contained"
             size="large"
+            type="submit"
             disabled={disabled}
             loading={loading}
             loadingPosition="end"
-            endIcon={null}
-            onClick={onSubmit}>
+            endIcon={null}>
             {text}
         </LoadingButton>
     )

--- a/components/authPages/Login.tsx
+++ b/components/authPages/Login.tsx
@@ -89,7 +89,8 @@ const Login = () => {
         }
     })
 
-    const onSubmit = () => {
+    const onSubmit = (e: any) => {
+        e.preventDefault()
         setLoading(true)
         handleLogin()
     }
@@ -97,7 +98,7 @@ const Login = () => {
     return (
         <section className={styles.AuthPage}>
             <Logo location="auth" />
-            <form>
+            <form onSubmit={onSubmit}>
                 <h1>Login</h1>
                 <TextField
                     label="Email"
@@ -164,7 +165,6 @@ const Login = () => {
                     disabled={disabled}
                     text="Login"
                     loading={loading}
-                    onSubmit={onSubmit}
                 />
                 <div className={styles.additionalInfo}>
                     <span>

--- a/components/authPages/Login.tsx
+++ b/components/authPages/Login.tsx
@@ -9,7 +9,6 @@ import {
     FormControlLabel
 } from '@mui/material'
 import { useDispatch } from 'react-redux'
-
 import { AccountCircle, Visibility, VisibilityOff } from '@mui/icons-material'
 import { useMutation } from '@apollo/client'
 
@@ -18,7 +17,7 @@ import useFormValidation from './utils/hooks/useFormValidation'
 import { LOGIN_USER } from '../../lib/graphql/mutations/user'
 import { VALID_PASSWORD, VALID_EMAIL } from '../../utilities/regex'
 
-import { login } from '../../lib/redux/userSlice'
+import { refreshUser } from '../../lib/redux/userSlice'
 import { showBanner } from '../../lib/redux/bannerSlice'
 
 import { JWT_SECRET } from '../../utilities/constants'
@@ -77,7 +76,7 @@ const Login = () => {
         onCompleted({ login: data }) {
             localStorage.setItem(JWT_SECRET, data.token)
             setLoading(false)
-            dispatch(login(data))
+            dispatch(refreshUser(data))
             router.push('/dashboard')
         },
         onError(err: any) {

--- a/components/authPages/Register.tsx
+++ b/components/authPages/Register.tsx
@@ -80,7 +80,8 @@ const Register = () => {
         }
     })
 
-    const onSubmit = () => {
+    const onSubmit = (e: any) => {
+        e.preventDefault()
         setLoading(true)
         handleRegister()
     }
@@ -88,7 +89,7 @@ const Register = () => {
     return (
         <section className={styles.AuthPage}>
             <Logo location="auth" />
-            <form>
+            <form onSubmit={onSubmit}>
                 <h1>Sign Up</h1>
                 <TextField
                     label="Email"
@@ -139,7 +140,6 @@ const Register = () => {
                     disabled={disabled}
                     loading={loading}
                     text="Register"
-                    onSubmit={onSubmit}
                 />
                 <div className={styles.additionalInfo}>
                     <span>

--- a/components/authPages/Register.tsx
+++ b/components/authPages/Register.tsx
@@ -1,13 +1,19 @@
 import { useState } from 'react'
 import { useDispatch } from 'react-redux'
+import { useRouter } from 'next/router'
 import Link from 'next/link'
-import { TextField, InputAdornment, IconButton, Button } from '@mui/material'
+import { TextField, InputAdornment, IconButton } from '@mui/material'
 import { AccountCircle, Visibility, VisibilityOff } from '@mui/icons-material'
+import { useMutation } from '@apollo/client'
 
+import { REGISTER_USER } from '../../lib/graphql/mutations/user'
 import ButtonWithLoader from './ButtonWithLoader'
 import useFormValidation from './utils/hooks/useFormValidation'
 import { VALID_PASSWORD, VALID_EMAIL } from '../../utilities/regex'
 import { closeBanner, showBanner } from '../../lib/redux/bannerSlice'
+import { register } from '../../lib/redux/userSlice'
+
+import { JWT_SECRET } from '../../utilities/constants'
 import styles from './AuthPages.module.scss'
 import Logo from '../logo'
 
@@ -18,6 +24,7 @@ type formValueTypes = {
 
 const Register = () => {
     const dispatch = useDispatch()
+    const router = useRouter()
     const { disabled, onValidation } = useFormValidation()
 
     const [email, setEmail] = useState<formValueTypes>({ value: '', error: '' })
@@ -25,6 +32,7 @@ const Register = () => {
         value: '',
         error: ''
     })
+    const [loading, setLoading] = useState(false)
     const [showPassword, setShowPassword] = useState(false)
 
     const onFieldUpdate = (e: any) => {
@@ -53,6 +61,28 @@ const Register = () => {
             default:
                 break
         }
+    }
+
+    const [handleRegister] = useMutation(REGISTER_USER, {
+        onCompleted({ register: data }) {
+            localStorage.setItem(JWT_SECRET, data.token)
+            setLoading(false)
+            dispatch(register(data))
+            router.push('/account')
+        },
+        onError(err) {
+            setLoading(false)
+            dispatch(showBanner({ status: 'error', message: err.message }))
+        },
+        variables: {
+            email: email.value,
+            password: password.value
+        }
+    })
+
+    const onSubmit = () => {
+        setLoading(true)
+        handleRegister()
     }
 
     return (
@@ -107,8 +137,9 @@ const Register = () => {
                 />
                 <ButtonWithLoader
                     disabled={disabled}
-                    loading={false}
+                    loading={loading}
                     text="Register"
+                    onSubmit={onSubmit}
                 />
                 <div className={styles.additionalInfo}>
                     <span>

--- a/components/layout/PageWrapper.tsx
+++ b/components/layout/PageWrapper.tsx
@@ -13,7 +13,7 @@ const PageWrapper = ({ children }: { children: any }) => {
     useEffect(() => {
         if (!user.loggedIn) {
             const token = decodeToken()
-            if (token) {
+            if (token?.id) {
                 dispatch(refreshUser(token))
             }
         }

--- a/components/nav/AuthNav.tsx
+++ b/components/nav/AuthNav.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Dashboard, Logout } from '@mui/icons-material'
 import { useDispatch } from 'react-redux'
+import { useRouter } from 'next/router'
 
 import { JWT_SECRET } from '../../utilities/constants'
 import { logout } from '../../lib/redux/userSlice'
@@ -9,11 +10,13 @@ import Logo from '../logo'
 import styles from './Nav.module.scss'
 
 const AuthNav = () => {
+    const router = useRouter()
     const dispatch = useDispatch()
 
     const onLogoutClick = () => {
-        logout()
         localStorage.removeItem(JWT_SECRET)
+        dispatch(logout())
+        router.push('/')
     }
 
     return (

--- a/components/nav/index.tsx
+++ b/components/nav/index.tsx
@@ -5,8 +5,7 @@ import AuthNav from './AuthNav'
 
 const NavBar = () => {
     const user = useSelector((state: any) => state.user)
-
-    if (!user?.id) {
+    if (!user?.loggedIn) {
         return <Nav />
     }
 

--- a/lib/graphql/mutations/user.ts
+++ b/lib/graphql/mutations/user.ts
@@ -9,3 +9,13 @@ export const LOGIN_USER = gql`
         }
     }
 `
+
+export const REGISTER_USER = gql`
+    mutation register($email: String!, $password: String!) {
+        register(email: $email, password: $password) {
+            id
+            email
+            token
+        }
+    }
+`

--- a/lib/redux/userSlice.ts
+++ b/lib/redux/userSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 
-type LoginAction = {
+type RegisterAction = {
     type: string
     payload: {
         email: string
@@ -49,32 +49,29 @@ export const userSlice = createSlice({
     name: 'user',
     initialState,
     reducers: {
-        login: (state, action: LoginAction) => {
+        register: (state, action: RegisterAction) => {
             state.email = action.payload.email
             state.id = action.payload.id
             state.loggedIn = true
         },
-        refreshUser: (state, action: RefreshUserAction) => {
-            state.email = action.payload.email
-            state.id = action.payload.id
-            state.firstName = action.payload.firstName
-            state.lastName = action.payload.lastName
-            state.dob = action.payload.dob
-            state.height = action.payload.height
-            state.weight = action.payload.weight
-            state.goalWeight = action.payload.goalWeight
-            state.bodyFat = action.payload.bodyFat
-            state.goalBodyFat = action.payload.goalBodyFat
-            state.activityLevel = action.payload.activityLevel
+        refreshUser: (state: any, action: RefreshUserAction) => {
+            for (const [key, value] of Object.entries(action.payload)) {
+                if (key === '__typename' || key === 'token') return
+
+                state[key] = value
+            }
             state.loggedIn = true
         },
-        logout: state => {
-            state = initialState
+        logout: (state: any) => {
+            Object.keys(state).forEach((key: string) => {
+                const copyOfInitial = initialState as any // TODO: Dig into this...
+                state[key] = copyOfInitial[key]
+            })
         }
     }
 })
 
 // Action creators are generated for each case reducer function
-export const { login, logout, refreshUser } = userSlice.actions
+export const { register, logout, refreshUser } = userSlice.actions
 
 export default userSlice.reducer

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -1,0 +1,5 @@
+const AccountPage = () => {
+    return <div>AccountPage</div>
+}
+
+export default AccountPage

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -29,4 +29,6 @@ a {
     box-shadow: 0px 0px 16px 3px rgba(0, 0, 0, 0.87);
     -webkit-box-shadow: 0px 0px 16px 3px rgba(0, 0, 0, 0.87);
     -moz-box-shadow: 0px 0px 16px 3px rgba(0, 0, 0, 0.87);
+    display: flex;
+    align-items: center;
 }


### PR DESCRIPTION
- Styled banner to properly display text inline with icon, vertically aligning
- Removed `onSubmit` prop from `ButtonWithLoader` component. Added on form submit event to form(s) (login & register for now), so user can submit by clicking button OR hitting enter
- replaced `login` redux call with `refreshUser`, added new `register` redux func
- Refactored `refreshUser` redux func to loop through available object key/value pairs and add them to the user state, instead of blanket updating the entire state even if there were no new additions to be added
- Added register mutation to register page, users can now login + register to the app directly
- Logout click now correctly clears user state from redux, removes token from local storage, and redirects user to the home page